### PR TITLE
Add simple chat feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ npm start
 ```
 
 The Express server runs on port `3001` and serves the built React application.
+
+## Chat Feature
+
+A basic chat is available on the right side of the page. Messages are stored in memory on the server.
+To try it out in development:
+
+1. Start the server as described above.
+2. Open the app in your browser and use the input on the right to send messages.

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import Chat from './Chat';
+import './Chat.css';
 
 function App() {
   const [message, setMessage] = useState('');
@@ -14,6 +16,7 @@ function App() {
     <div>
       <h1>React + Node</h1>
       <p>{message}</p>
+      <Chat />
     </div>
   );
 }

--- a/client/src/Chat.css
+++ b/client/src/Chat.css
@@ -1,0 +1,32 @@
+.chat-container {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 250px;
+  height: 100vh;
+  background: #f5f5f5;
+  border-left: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.chat-entry {
+  margin-bottom: 0.25rem;
+}
+
+.chat-form {
+  display: flex;
+  padding: 0.5rem;
+  border-top: 1px solid #ccc;
+}
+
+.chat-form input {
+  flex: 1;
+  margin-right: 0.5rem;
+}

--- a/client/src/Chat.js
+++ b/client/src/Chat.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+
+function Chat() {
+  const [messages, setMessages] = useState([]);
+  const [newMessage, setNewMessage] = useState('');
+
+  useEffect(() => {
+    fetch('/api/chat')
+      .then((res) => res.json())
+      .then((data) => setMessages(data))
+      .catch(() => setMessages([]));
+  }, []);
+
+  const sendMessage = (e) => {
+    e.preventDefault();
+    if (!newMessage.trim()) return;
+    fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: newMessage })
+    })
+      .then((res) => res.json())
+      .then((msg) => {
+        setMessages((prev) => [...prev, msg]);
+        setNewMessage('');
+      });
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="chat-log">
+        {messages.map((m) => (
+          <div key={m.id} className="chat-entry">{m.message}</div>
+        ))}
+      </div>
+      <form onSubmit={sendMessage} className="chat-form">
+        <input
+          type="text"
+          value={newMessage}
+          onChange={(e) => setNewMessage(e.target.value)}
+          placeholder="Type a message"
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+
+export default Chat;

--- a/server.js
+++ b/server.js
@@ -6,8 +6,24 @@ const PORT = process.env.PORT || 3001;
 
 app.use(express.json());
 
+const chatMessages = [];
+
 app.get('/api/message', (req, res) => {
   res.json({ message: 'Hello from server!' });
+});
+
+app.get('/api/chat', (req, res) => {
+  res.json(chatMessages);
+});
+
+app.post('/api/chat', (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ error: 'Message is required' });
+  }
+  const entry = { id: Date.now(), message };
+  chatMessages.push(entry);
+  res.status(201).json(entry);
 });
 
 app.use(express.static(path.join(__dirname, 'client', 'build')));


### PR DESCRIPTION
## Summary
- support in-memory chat endpoints in server
- implement Chat component with input and log
- show chat UI in App component
- add basic chat styles
- document chat feature in README

## Testing
- `CI=true npm test --prefix client --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_687f9ad4ae6c832cb0348ec3e2b28ead