### PR TITLE
Fix tic-tac-toe square visibility

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -16,17 +16,19 @@
   width: 60px;
   height: 60px;
   font-size: 2rem;
-  color: var(--primary-color); /* Changed from --text-color */
-  background-color: var(--secondary-color);
+  color: var(--primary-color);
+  background-color: var(--background-color);
   border: 1px solid var(--primary-color);
   cursor: pointer;
   padding: 0;
 }
 
+.square:hover,
 .square:focus,
 .square:active {
   outline: none;
-  color: #fff; /* Text turns white when highlighted */
+  color: #fff;
+  background-color: var(--secondary-color);
 }
 
 .status {


### PR DESCRIPTION
## Summary
- adjust `.square` styles so X and O are visible

## Testing
- `npm run build --prefix client`
- `CI=true npm test --prefix client --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_687fcc691788832c9ad4597eebb2b1d6